### PR TITLE
fix: removed comments for the organizers

### DIFF
--- a/data/sessions/revolutionnez_votre_prise_de_notes___du_bullet_journal_a_obsidian.yml
+++ b/data/sessions/revolutionnez_votre_prise_de_notes___du_bullet_journal_a_obsidian.yml
@@ -12,10 +12,6 @@ speakers:
 slot: day-2-conference-2
 room: Titan
 abstract: |-
-  **Format :**
-  40 min
-
-  **Description :**
   En 2025, où tout va très voire trop vite, prendre des notes est devenu essentiel.
 
   Cette pratique permet non seulement de ralentir et ainsi de mieux intégrer l'information, mais elle permet aussi de planifier efficacement ses actions futures.
@@ -27,9 +23,3 @@ abstract: |-
   Au delà de cette habitude, j'utilise aussi la prise de notes pour structurer mes actions dans le futur en définissant un plan par tranches de temp (annuel, trimestriel, mensuel et hebdomadaire).
 
   Que vous soyez curieux des avantage de la prise de notes où que souhaitez moderniser votre propre méthode, ce talk est fait pour vous.
-
-  **Objectif du talk :**
-  L'objectif de ce talk est d'introduire les participants à une méthodologie avancée de prise de notes qui combine les avantages du Bullet Journal avec la puissance numérique d'Obsidian, les aidant ainsi à capitaliser leurs actions, leurs acquis et leur veille tout en envisageant des stratégies pour inscrire leurs projets dans le temps avenir. Si ce talk permet a une seule personne de trouver la volonté de commencer à prendre des notes, même papier, et de lui donner l'impulsion nécessaire et des idées pour expérimenter les outils qui lui conviendraient le mieux, je considèrerais que ma mission est accomplie.
-
-  **Notes pour les organisateurs :**
-  Ce talk s'appuie sur plusieurs années d'expérience avec les outils numériques de prise de notes et la gestion de projets. Il inclut des démonstrations en live, des exemples concrets de mise en œuvre d'une organisation des notes quotidiennes et des exemples d'utilisation de plugins essentiels pour tirer tout le potentiel caché d'Obsidian. De façon générale, ce talk s'adresse à tous ceux cherchant à améliorer leur méthode d'organisation personnelle.


### PR DESCRIPTION
Rework of my talk description to remove any unnecessary comments initially intended to be read by the organizers