### PR TITLE
fix: Android app link

### DIFF
--- a/src/components/commun/mobileApp.tsx
+++ b/src/components/commun/mobileApp.tsx
@@ -38,7 +38,7 @@ export const MobileAppButton: React.FC<{ label: string }> = ({ label }) => {
               <Button
                 color='secondary'
                 variant='contained'
-                href='https://play.google.com/store/apps/details?id=com.gdgnantes.devfest.androidapp&pli=1'
+                href='https://play.google.com/store/apps/details?id=com.gdgnantes.devfest.mobile.androidapp&pcampaignid=web_share'
                 aria-label='Android app'
                 target={'_blank'}
                 startIcon={<Android />}

--- a/src/components/home/jumbo.tsx
+++ b/src/components/home/jumbo.tsx
@@ -205,7 +205,7 @@ export const HomeJumbo: MyComponent = ({ params }) => {
               <Button
                 color="secondary"
                 variant="contained"
-                href="https://play.google.com/store/apps/details?id=com.gdgnantes.devfest.androidapp&pli=1"
+                href="https://play.google.com/store/apps/details?id=com.gdgnantes.devfest.mobile.androidapp&pcampaignid=web_share"
                 aria-label="Android app"
                 target={"_blank"}
                 startIcon={<Android/>}


### PR DESCRIPTION
This pull request updates the Google Play Store link for the Android app in two components to use the new package name and adds a campaign tracking parameter.

Android app link update:

* Changed the Play Store URL in `MobileAppButton` (`src/components/commun/mobileApp.tsx`) to use the new package name `com.gdgnantes.devfest.mobile.androidapp` and added the `pcampaignid=web_share` parameter for tracking.
* Updated the Play Store URL in `HomeJumbo` (`src/components/home/jumbo.tsx`) to match the new package name and include the campaign tracking parameter.