### PR TITLE
Fix Bluesky URL construction logic

### DIFF
--- a/src/components/commun/socials/socials.tsx
+++ b/src/components/commun/socials/socials.tsx
@@ -67,7 +67,7 @@ export const SocialLink: React.FC<
     url = social.url;
   } else if (social.type === 'bluesky') {
     icon = <Image src={Bluesky} alt={'logo bluesky'} width={22} height={22} />;
-    url = `https://bsky.app/profile/${social.login}.bsky.social`;
+    url = `https://bsky.app/profile/${social.login}${social.login.includes('.') ? '' : '.bsky.social'}`;
   } else {
     url = '';
   }


### PR DESCRIPTION
If the bluesky login use a custom domain name, the url isn't good. This correction add the .bsky.social suffix only if the login hasn't dot in the login.