### PR TITLE
feat(a11y+seo): implement skip-link, ARIA landmarks, enriched metadata

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -13,6 +13,8 @@ const URLSite = 'https://devfest2025.gdgnantes.com';
 export async function generateMetadata({
   params,
 }: CommonParams): Promise<Metadata> {
+  const resolved = await params;
+  const locale = resolved?.locale || i18nConfig.defaultLocale;
   const t = await getTranslation(params);
   return {
     title: 'Devfest Nantes',
@@ -52,7 +54,7 @@ export async function generateMetadata({
       title: 'Devfest Nantes',
       description: t('site.description'),
       siteName: 'Devfest Nantes',
-      locale: params?.locale === 'en' ? 'en_US' : 'fr_FR',
+      locale: locale === 'en' ? 'en_US' : 'fr_FR',
       images: [
         {
           url: '/opengraph-image.jpg',

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -31,8 +31,49 @@ export async function generateMetadata({
         fr: '/',
       },
     },
+    applicationName: 'Devfest Nantes 2025',
+    keywords: ['Devfest', 'GDG Nantes', 'Conference', 'Tech', 'Developers', 'Nantes'],
+    themeColor: '#111827',
+    robots: {
+      index: true,
+      follow: true,
+      nocache: false,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-image-preview': 'large',
+        'max-video-preview': -1,
+        'max-snippet': -1,
+      },
+    },
+    openGraph: {
+      type: 'website',
+      url: URLSite,
+      title: 'Devfest Nantes',
+      description: t('site.description'),
+      siteName: 'Devfest Nantes',
+      locale: params?.locale === 'en' ? 'en_US' : 'fr_FR',
+      images: [
+        {
+          url: '/opengraph-image.jpg',
+          width: 1200,
+          height: 630,
+          alt: 'Devfest Nantes',
+        },
+      ],
+    },
     twitter: {
       site: '@devfestnantes',
+      card: 'summary_large_image',
+      title: 'Devfest Nantes',
+      description: t('site.description'),
+      images: ['/twitter-image.jpg'],
+    },
+    viewport: {
+      width: 'device-width',
+      initialScale: 1,
+      viewportFit: 'cover',
+      themeColor: '#111827',
     },
   };
 }
@@ -48,15 +89,33 @@ const RootLayout: MyComponent = async ({ children, params }) => {
   return (
     <html lang={locale} className={htmlClass}>
       <body className={bodyClass}>
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
+            .skip-link { position: absolute; left: -10000px; top: auto; background: #111827; color: #ffffff; padding: 8px 12px; z-index: 1000; }
+            .skip-link:focus { left: 8px; top: 8px; }
+          `,
+          }}
+        />
+        {/* Skip to content for accessibility */}
+        <a href="#main-content" className="skip-link">
+          Skip to content
+        </a>
         <script
           type='application/ld+json'
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
         <Analytics />
         <MuiProvider>
-          <Navbar params={params} />
-          <main>{children}</main>
-          <Footer params={params} />
+          <nav aria-label='Primary'>
+            <Navbar params={params} />
+          </nav>
+          <main id='main-content' role='main'>
+            {children}
+          </main>
+          <footer role='contentinfo'>
+            <Footer params={params} />
+          </footer>
         </MuiProvider>
       </body>
     </html>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from 'next';
+
+const SITE_URL = 'https://devfest2025.gdgnantes.com';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    host: SITE_URL.replace(/^https?:\/\//, ''),
+    sitemap: [
+      `${SITE_URL}/sitemap.xml`,
+    ],
+  };
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="react" />
+/// <reference types="react-dom" />


### PR DESCRIPTION

## Summary

Enhances **accessibility, SEO, and TypeScript** across the app:

* Adds skip-to-content link and ARIA landmarks.
* Enriches metadata (Open Graph, Twitter, robots, viewport, app name, theme color).
* Adds runtime App Router `robots.ts`.
* Fixes JSX type issues with local TypeScript declarations.

## Key Changes

* **Accessibility**: Skip link in `layout.tsx`; ARIA landmarks for nav, main, and footer.
* **SEO/Metadata**: Updated `generateMetadata()` with localized descriptions and locale-aware Open Graph.
* **Robots**: `src/app/robots.ts` serves robots.txt with Host and Sitemap.
* **TypeScript**: `src/types/global.d.ts` fixes JSX intrinsic types without ignored files.

## Rationale

* Improves keyboard/screen-reader navigation.
* Boosts SEO and social link previews.
* Provides explicit robots configuration.
* Keeps TypeScript setup clean.
------